### PR TITLE
add benchmark to mapwindow version

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 LocalBinaryPatterns = "182d5feb-7f97-4ee5-8ac5-0fa9e747ecb3"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,6 +6,8 @@ using ImageTransformations
 using TestImages
 using ImageCore
 
+include("mapwindow_impl.jl")
+
 on_CI = haskey(ENV, "GITHUB_ACTIONS")
 
 img = testimage("cameraman")
@@ -35,4 +37,15 @@ for (alg_name, alg) in alg_list
     add_algorithm_benchmark!(SUITE, img, alg_name, alg;
                              tst_sizes=tst_sizes,
                              tst_types=tst_types)
+end
+
+
+# compare with the simple mapwindow version
+suite = SUITE["Original (mapwindow)"] = BenchmarkGroup()
+for T in tst_types
+    haskey(suite, T) || (suite[T] = BenchmarkGroup())
+    for sz in tst_sizes
+        tst_img = imresize(T.(img), (sz, sz))
+        suite[T]["$sz×$sz"] = @benchmarkable lbp_origin_mapwindow($tst_img)
+    end
 end

--- a/benchmark/mapwindow_impl.jl
+++ b/benchmark/mapwindow_impl.jl
@@ -1,0 +1,16 @@
+using ImageFiltering
+
+function lbp_origin_mapwindow(X)
+    function _lbp(block)
+        gc = block[2, 2]
+        offsets = ((-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1))
+
+        rst = 0
+        for i in 1:length(offsets)
+            o = offsets[i]
+            rst += ifelse(gc <= block[2+o[1], 2+o[2]], 1, 0) << (i-1)
+        end
+        return rst
+    end
+    mapwindow(_lbp, X, (3, 3))
+end


### PR DESCRIPTION
It shows that this package provides about 4x faster implementation than the simple `mapwindow` version.

```julia
using LocalBinaryPatterns
using PkgBenchmark

results = PkgBenchmark.benchmarkpkg(LocalBinaryPatterns)
```

# Benchmark Report

## Job Properties
* Time of benchmark: 27 Nov 2021 - 17:58
* Package commit: 901ada
* Julia commit: 3348de
* Julia command flags: None
* Environment variables: None

## Results
Below is a table of this job's results, obtained by running the benchmarks.
The values listed in the `ID` column have the structure `[parent_group, child_group, ..., key]`, and can be used to
index into the BaseBenchmarks suite to retrieve the corresponding benchmarks.
The percentages accompanying time and memory values in the below table are noise tolerances. The "true"
time/memory value for a given benchmark is expected to fall within this percentage of the reported value.
An empty cell means that the value was zero.

| ID                                                     | time            | GC time | memory          | allocations |
|--------------------------------------------------------|----------------:|--------:|----------------:|------------:|
| `["Original (mapwindow)", "Float32", "256×256"]`       |   2.006 ms (5%) |         |   1.44 MiB (1%) |       19404 |
| `["Original (mapwindow)", "Float32", "512×512"]`       |   7.156 ms (5%) |         |   3.87 MiB (1%) |       38860 |
| `["Original (mapwindow)", "Gray{Float32}", "256×256"]` |   1.936 ms (5%) |         |   1.34 MiB (1%) |       16340 |
| `["Original (mapwindow)", "Gray{Float32}", "512×512"]` |   6.840 ms (5%) |         |   3.69 MiB (1%) |       32724 |
| `["Original (mapwindow)", "Gray{N0f8}", "256×256"]`    |   1.798 ms (5%) |         |   1.43 MiB (1%) |       19403 |
| `["Original (mapwindow)", "Gray{N0f8}", "512×512"]`    |   6.291 ms (5%) |         |   3.87 MiB (1%) |       38859 |
| `["Original (mapwindow)", "N0f8", "256×256"]`          |   1.915 ms (5%) |         |   1.34 MiB (1%) |       16340 |
| `["Original (mapwindow)", "N0f8", "512×512"]`          |   6.750 ms (5%) |         |   3.69 MiB (1%) |       32724 |
| `["Original", "Float32", "256×256"]`                   | 212.147 μs (5%) |         |  64.11 KiB (1%) |           2 |
| `["Original", "Float32", "512×512"]`                   | 823.031 μs (5%) |         | 256.11 KiB (1%) |           2 |
| `["Original", "Gray{Float32}", "256×256"]`             | 212.185 μs (5%) |         |  64.11 KiB (1%) |           2 |
| `["Original", "Gray{Float32}", "512×512"]`             | 819.720 μs (5%) |         | 256.11 KiB (1%) |           2 |
| `["Original", "Gray{N0f8}", "256×256"]`                | 248.887 μs (5%) |         |  64.11 KiB (1%) |           2 |
| `["Original", "Gray{N0f8}", "512×512"]`                | 966.303 μs (5%) |         | 256.11 KiB (1%) |           2 |
| `["Original", "N0f8", "256×256"]`                      | 249.499 μs (5%) |         |  64.11 KiB (1%) |           2 |
| `["Original", "N0f8", "512×512"]`                      | 946.690 μs (5%) |         | 256.11 KiB (1%) |           2 |

## Benchmark Group List
Here's a list of all the benchmark groups executed by this job:

- `["Original (mapwindow)", "Float32"]`
- `["Original (mapwindow)", "Gray{Float32}"]`
- `["Original (mapwindow)", "Gray{N0f8}"]`
- `["Original (mapwindow)", "N0f8"]`
- `["Original", "Float32"]`
- `["Original", "Gray{Float32}"]`
- `["Original", "Gray{N0f8}"]`
- `["Original", "N0f8"]`

## Julia versioninfo
```
Julia Version 1.7.0-rc3
Commit 3348de4ea6 (2021-11-15 08:22 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin19.6.0)
  uname: Darwin 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5/RELEASE_X86_64 x86_64 i386
  CPU: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz: 
                 speed         user         nice          sys         idle          irq
       #1-16  2300 MHz    7118218 s          0 s    4286594 s  182214125 s          0 s
       
  Memory: 32.0 GB (7658.578125 MB free)
  Uptime: 2.412524e6 sec
  Load Avg:  2.7890625  2.41064453125  2.365234375
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)
```