### PR TITLE
implement uniform encoding pass

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -17,7 +17,6 @@ tst_types = (N0f8, Float32, Gray{N0f8}, Gray{Float32})
 const SUITE = BenchmarkGroup()
 
 alg_list = (( "Original", lbp_original),
-            ( "Rotation-Invariant", lbp_rotation_invariant),
             )
 
 function add_algorithm_benchmark!(suite, img, alg_name, alg;

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -4,3 +4,7 @@ if VERSION < v"1.5"
         (x << ((sizeof(T) << 3 - 1) & k)) | (x >>> ((sizeof(T) << 3 - 1) & -k))
     end
 end
+
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,20 +1,33 @@
-# This implements the solver for Eq. (8) in the Ojala 2002 as lookup table.
-# Computing the encoding table using naive implementation is time-consuming,
-# since it's read-only, we simply cache the encoding table.
-const _rotation_invariant_encoding_tables = Dict()
 const SupportedEncodingTypes = Union{UInt8, UInt16}
-function build_rotation_invariant_encoding_table(::Type{T}) where T<:SupportedEncodingTypes
-    d = _rotation_invariant_encoding_tables
-    haskey(d, T) && return d[T]
-    d[T] = _freeze(T, _build_inverse_table(_bitrotate_quotation_space(T)))
-    return d[T]
+const _LBP_encoding_table = Dict()
+function build_LBP_encoding_table(::Type{T};
+        rotation::Bool,
+        uniform_degree::Union{Nothing,Int}=nothing
+    ) where T<:SupportedEncodingTypes
+
+    d = _LBP_encoding_table
+    p = (T, rotation, uniform_degree)
+    haskey(d, p) && return d[p]
+
+    identity_lookup = identity.(typemin(T):typemax(T))
+    rot_lookup = rotation ? _build_inverse_table(_bitrotate_quotation_space(T)) : identity_lookup
+    uniform_lookup = !isnothing(uniform_degree) ? _uniform_encoding_table(T, uniform_degree) : identity_lookup
+
+    # Chaining multiple encoding passes into one lookup table so that we can move as
+    # much computation to warm-up phase as we can.
+    lookup = d[p] = _freeze(T, uniform_lookup[rot_lookup.+1])
+    return lookup == identity_lookup ? nothing : lookup
 end
 
-# Mathematically, this is the quotation space under circular bitshift of the N-bits binary
-# pattern space. For instance, 0b00001101 and 0b01000011 belong to the same equivalance
-# class.
-# TODO(johnnychen94): maybe support UInt32 and beyond by providing a more efficient implementation
 function _bitrotate_quotation_space(::Type{T}) where T<:SupportedEncodingTypes
+    # Mathematically, this is the quotation space under circular bitshift of the N-bits binary
+    # pattern space. For instance, 0b00001101 and 0b01000011 belong to the same equivalance
+    # class.
+    # TODO(johnnychen94): maybe support UInt32 and beyond by providing a more efficient implementation
+
+    # This implements the solver for Eq. (8) in the Ojala 2002 as lookup table.
+    # Computing the encoding table using naive implementation is time-consuming,
+    # since it's read-only, we simply cache the encoding table.
     s = Vector{T}[]
     for x in typemin(T):typemax(T)
         # without the following skipping mechanism actually runs faster
@@ -23,6 +36,18 @@ function _bitrotate_quotation_space(::Type{T}) where T<:SupportedEncodingTypes
     end
     Dict(minimum(c) => c for c in unique!(s))
 end
+
+function _uniform_encoding_table(::Type{T}, degree::Int) where T<:SupportedEncodingTypes
+    function _count_bit_transitions(x)
+        count_ones(x << 7 & typemax(typeof(x))) + count_ones(x ⊻ (x >> 1))
+    end
+    # Eq. (9) for Ojala 2002
+    map(typemin(T):typemax(T)) do x
+        n = _count_bit_transitions(x)
+        ifelse(n > degree, 8sizeof(T)+1, x)
+    end
+end
+
 function _build_inverse_table(d::Dict{T,<:AbstractVector{T}}) where {T}
     id = Vector{T}(undef, typemax(T)-typemin(T)+1)
     for k in keys(d)

--- a/test/lbp_original.jl
+++ b/test/lbp_original.jl
@@ -43,4 +43,24 @@
         @test size(out) == (3, 3)
         @test out == ref_out
     end
+
+    @testset "Uniform encoding" begin
+        X = [6 7 9; 5 6 3; 2 1 7]
+        ref_out = [192 64 0; 9 9 9; 9 9 0]
+
+        out = lbp_original(X; rotation=false, uniform_degree=2)
+        @test eltype(out) == UInt8
+        @test size(out) == (3, 3)
+        @test out == ref_out
+    end
+
+    @testset "Rotation Invariant, Uniform encoding" begin
+        X = [6 7 9; 5 6 3; 2 1 7]
+        ref_out = [3 1 0; 9 9 9; 9 9 0]
+
+        out = lbp_original(X; rotation=true, uniform_degree=2)
+        @test eltype(out) == UInt8
+        @test size(out) == (3, 3)
+        @test out == ref_out
+    end
 end


### PR DESCRIPTION
24x faster than ImageFeatures this time

```julia
using ImageFeatures, TestImages, ImageCore

img = float32.(testimage("camera"));

@btime lbp($img, $lbp_rotation_invariant); # 36.187 ms (136 allocations: 2.01 MiB)
@btime lbp_ri($img); # 1.572 ms (8 allocations: 4.25 MiB)
```