### PR TITLE
support modified LBP with `average_mode`

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -4,6 +4,12 @@
 lbp_original
 ```
 
+## Helpers
+
+```@docs
+LocalBinaryPatterns.average_mode
+```
+
 ## Internal utilities
 
 ```@docs

--- a/src/lbp_original.jl
+++ b/src/lbp_original.jl
@@ -292,8 +292,8 @@ Base.@propagate_inbounds function average_mode(X, I::CartesianIndex, offsets)
     ax = axes(X)
     rst = v + mapreduce(+, offsets) do o
         p = I.I .+ o
-        inbound = mapreduce(in, &, p, ax)
-        inbound ? _inbounds_getindex(X, p) : v
+        inbounds = map(in, p, ax)
+        all(inbounds) ? _inbounds_getindex(X, p) : v
     end
     return rst / (length(offsets) + 1)
 end

--- a/src/lbp_original.jl
+++ b/src/lbp_original.jl
@@ -5,8 +5,8 @@ Compute the local binary pattern of gray image `X` using the original method.
 
 # Arguments
 
-- `f`: `f(X, I, offsets)` computes the block mode value. In the original version [1]
-  it directly uses the center pixel value, i.e., `f(X, I, offsets) = X[I]`.
+- `f`: function `f(X, I, offsets)` computes the block mode value. In the original version
+  [1] it directly uses the center pixel value, i.e., `f(X, I, offsets) = X[I]`.
   See also [`average_mode`](@ref LocalBinaryPatterns).
 - `X::AbstractMatrix`: the input image matrix. For colorful images, one can manually convert
   it to some monochrome space, e.g., `Gray`, the L-channel of `Lab`. One could also do
@@ -120,14 +120,24 @@ This produces better result for `rotation=true` case but is usually slower than 
 
 # Arguments
 
-- `npoints::Int`(4 ≤ npoints ≤ 32): the number of (uniform-spaced) neighborhood points. It
-    is recommended to use one of {4, 8, 12, 16, 24}.
+- `npoints::Int`(4 ≤ npoints ≤ 32): the number of (uniform-spaced) neighborhood points.
 - `radius::Real`(radius ≥ 1.0): the radius of the circular. Larger radius computes the
     pattern of a larger local window/block.
 - `interpolation::Union{Degree, InterpolationType}=Linear()`: the interpolation method used
     to generate non-grid pixel value. In most cases, `Linear()` are good enough. One can
     also try other costly interpolation methods, e.g., `Cubic(Line(OnGrid()))`(also known as
     "bicubic"), `Lanczos()`. See also Interpolations.jl for more choices.
+
+!!! info "parameter choices"
+    The following parameters are used in [1], with `interpolation=Linear()`.
+
+    | `npoints` | `radius` |
+    | --- | --- |
+    | ``4`` | ``1.0`` |
+    | ``8`` | ``1.0`` |
+    | ``12`` | ``1.5`` |
+    | ``16`` | ``2.0`` |
+    | ``24`` | ``3.0`` |
 
 !!! note "neighborhood order differences"
     Different implementation might use different neighborhood orders; this will change the
@@ -158,6 +168,9 @@ julia> lbp_original(X, 4, 1; rotation=true)
  0x00000001  0x00000007  0x00000000
 ```
 
+# References
+
+- [1] T. Ojala, M. Pietikainen, and T. Maenpaa, “Multiresolution gray-scale and rotation invariant texture classification with local binary patterns,” _IEEE Trans. Pattern Anal. Machine Intell._, vol. 24, no. 7, pp. 971–987, Jul. 2002, doi: 10.1109/TPAMI.2002.1017623.
 """
 function lbp_original(
         f, X::AbstractArray, npoints::Int, radius::Real, interpolation=Linear();

--- a/test/lbp_original.jl
+++ b/test/lbp_original.jl
@@ -1,3 +1,5 @@
+using LocalBinaryPatterns: average_mode
+
 @testset "lbp_original" begin
     # reference result comes from [1]
     # - [1] T. Ojala, M. Pietikäinen, and D. Harwood, “A comparative study of texture measures with classification based on featured distributions,” _Pattern Recognition_, vol. 29, no. 1, pp. 51–59, Jan. 1996, doi: 10.1016/0031-3203(95)00067-4.
@@ -139,4 +141,27 @@ end
         @test_nowarn lbp_original(X, 4, 1.5)
         @test_throws ArgumentError lbp_original(X, 4, 0.5)
     end
+end
+
+@testset "average mode" begin
+    X = [6 7 9; 5 6 3; 2 1 7]
+    ref_out = [192 64 0; 104 169 27; 40 105 1]
+    out = lbp_original(average_mode, X)
+    @test eltype(out) == UInt8
+    @test size(out) == (3, 3)
+    @test out == ref_out
+
+    X = [6 7 9; 5 6 3; 2 1 7]
+    ref_out = [3 1 0; 13 53 27; 5 45 1]
+    out = lbp_original(average_mode, X, rotation=true)
+    @test eltype(out) == UInt8
+    @test size(out) == (3, 3)
+    @test out == ref_out
+
+    X = [6 7 9; 5 6 3; 2 1 7]
+    ref_out = [1 1 0; 3 6 28; 2 15 0]
+    out = lbp_original(average_mode, X, 6, 1)
+    @test eltype(out) == UInt32
+    @test size(out) == (3, 3)
+    @test out == ref_out
 end


### PR DESCRIPTION

```julia
using TestImages, ImageCore
using LocalBinaryPatterns
using ImageFeatures

img = float32.(testimage("camera"));

# original + average: 4x faster
@btime modified_lbp($img, $lbp_original); # 23.296 ms (14 allocations: 2.00 MiB)
@btime lbp_original($average_mode, $img); # 5.409 ms (3 allocations: 256.16 KiB)

# interpolation + average: 1.8x faster
@btime modified_lbp($img, 24, 3, $lbp_original); # 225.435 ms (15 allocations: 2.00 MiB)
@btime lbp_original($average_mode, $img, 24, 2); # 120.412 ms (32 allocations: 2.00 MiB)
```