### PR TITLE
feat: add Multi-block LBP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.1.0"
 
 [deps]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+IntegralArrays = "1d092043-8f09-5a30-832f-7509e371ab51"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TiledIteration = "06e1c1a7-607b-532d-9fad-de7d9aa2abac"
 
 [compat]
 ImageCore = "0.8, 0.9"
+IntegralArrays = "0.1.2"
 Interpolations = "0.12, 0.13"
 StaticArrays = "0.12, 1"
 TiledIteration = "0.2, 0.3"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,7 +16,10 @@ tst_types = (N0f8, Float32, Gray{N0f8}, Gray{Float32})
 
 const SUITE = BenchmarkGroup()
 
-alg_list = (( "Original", lbp_original),
+alg_list = (("Original", lbp_original),
+            ("Multi-block (1x1)", img->multiblock_lbp(img, (1, 1))),
+            ("Multi-block (3x3)", img->multiblock_lbp(img, (3, 3))),
+            ("Multi-block (5x5)", img->multiblock_lbp(img, (5, 5))),
             )
 
 function add_algorithm_benchmark!(suite, img, alg_name, alg;

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,7 +12,7 @@ on_CI = haskey(ENV, "GITHUB_ACTIONS")
 
 img = testimage("cameraman")
 tst_sizes = (256, 512)
-tst_types = (N0f8, Float32, Gray{N0f8}, Gray{Float32})
+tst_types = (Gray{N0f8}, Gray{Float32})
 
 const SUITE = BenchmarkGroup()
 

--- a/src/LocalBinaryPatterns.jl
+++ b/src/LocalBinaryPatterns.jl
@@ -5,10 +5,12 @@ using Interpolations
 using ImageCore
 using ImageCore.OffsetArrays
 using StaticArrays
+using IntegralArrays
 
-export lbp_original
+export lbp_original, multiblock_lbp
 
 include("lbp_original.jl")
+include("multiblock_lbp.jl")
 
 include("bitrotate_encoding.jl")
 include("uniform_encoding.jl")

--- a/src/multiblock_lbp.jl
+++ b/src/multiblock_lbp.jl
@@ -1,0 +1,126 @@
+"""
+    multiblock_lbp(X, block_size; [rotation], [uniform_degree])
+
+Compute the local binary pattern of gray image `X` of image blocks with size `block_size`.
+
+# Arguments
+
+- `X::AbstractMatrix`: the input image matrix. For colorful images, one can manually convert
+  it to some monochrome space, e.g., `Gray`, the L-channel of `Lab`. One could also do
+  channelwise LBP and then concatenate together.
+- `block_size::Tuple{Int,Int}`: odd integers that used to specify the size of each block. When
+  `block_size == (1, 1)`, this method degenerates to the pixel-version [`lbp_original`](@ref).
+
+For the meaning and values of parameters `rotation` and `uniform_degree` please see the docs
+of [`lbp_original`](@ref).
+
+# Examples
+
+```jldoctest; setup=:(using LocalBinaryPatterns)
+julia> X = zeros(Int, 9, 9); X[1:3, 1:3] .= 50; X[4:6, 4:6] .= 1; X[7:9, 7:9] .= 50; X
+9×9 $(Matrix{Int}):
+ 50  50  50  0  0  0   0   0   0
+ 50  50  50  0  0  0   0   0   0
+ 50  50  50  0  0  0   0   0   0
+  0   0   0  1  1  1   0   0   0
+  0   0   0  1  1  1   0   0   0
+  0   0   0  1  1  1   0   0   0
+  0   0   0  0  0  0  50  50  50
+  0   0   0  0  0  0  50  50  50
+  0   0   0  0  0  0  50  50  50
+
+julia> multiblock_lbp(X, (3, 3))[5, 5] # 0b1000_0001
+0x81
+
+julia> multiblock_lbp(X, (3, 3); rotation=true)[5, 5] # 0b0000_0011
+0x03
+
+julia> multiblock_lbp(X, (3, 3); uniform_degree=2)[5, 5] # 0x09 (i.e., miscellaneous pattern)
+0x09
+```
+
+# Extended help
+
+The following is how the block-version of local binary pattern computed with
+`block_size=(3, 3)`. Check out [`lbp_original`](@ref) for more details of the original
+pixel-version of local binary pattern.
+
+```text
+2  3  2  |  7  6  6  |  2  1  3
+1  2  3  |  5  3  4  |  7  7  3
+6  5  4  |  1  4  5  |  1  5  8
+-------------------------------     sum                compare          weighted          sum
+1  2  3  |  1  7  3  |  8  3  7            28  41  37           0  1  0           0 8 0
+1  2  1  |  4  3  6  |  5  2  2     ==>    20  38  45    ==>    0  x  1     ==>   0 x 64  ==> 200
+1  2  7  |  5  3  6  |  4  7  7            33  31  39           0  0  1           0 0 128
+-------------------------------
+4  2  4  |  8  1  5  |  3  7  7
+5  7  4  |  1  1  1  |  3  4  3
+3  3  1  |  5  1  8  |  1  8  3
+```
+
+# References
+
+- [1] Zhang, Lun, et al. "Face detection based on multi-block lbp representation." _International conference on biometrics_. Springer, Berlin, Heidelberg, 2007.
+"""
+function multiblock_lbp(X::AbstractArray, block_size::Dims{2}; rotation::Bool=false, uniform_degree::Union{Nothing,Int}=nothing)
+    offsets = ((-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1), (0, 1), (1, 1))
+    lookups = _build_lbp_original_lookup(UInt8, 8; rotation=rotation, uniform_degree=uniform_degree)
+    multiblock_lbp!(similar(X, UInt8), X, offsets, lookups, block_size)
+end
+
+function multiblock_lbp!(out, X::AbstractMatrix, offsets, lookups, block_size::Dims{2})
+    all(isodd, block_size) || throw(ArgumentError("block size `block_size=$(block_size)` should be odd numbers."))
+    offsets = map(offsets) do o
+        o .* block_size
+    end
+    bo = CartesianIndex(block_size .÷ 2)
+
+    # It's computationally more efficient to use integral array to compute
+    # the mean block value.
+    iX = IntegralArray(X)
+
+    outerR = CartesianIndices(X)
+    r = CartesianIndex(
+        ceil(Int, maximum(abs.(extrema(first.(offsets))))),
+        ceil(Int, maximum(abs.(extrema(last.(offsets)))))
+    )
+    innerR = first(outerR)+r+bo:last(outerR)-r-bo
+
+    # TODO(johnnychen94): use LoopVectorization
+    @inbounds for I in innerR
+        # since the block is regular for inner region, doing sum is equivalent to doing average.
+        gc = iX[I-bo..I+bo]
+        # This inner loop fuses the binary pattern build stage and encoding stage for
+        # better performance.
+        rst = 0
+        # TODO(johnnychen94): it can be faster if we can enable SIMD here.
+        #                     Need to skip the boundary check in IntegralArray.
+        for i in 1:length(offsets)
+            p = CartesianIndex(I.I .+ offsets[i])
+            rst += ifelse(gc <= iX[p-bo..p+bo], 1, 0) << (i-1)
+        end
+        out[I] = rst
+    end
+
+    # boundary conditions are undefined in [1]; here we directly skip out-of-boundary values
+    @inbounds for I in EdgeIterator(outerR, innerR)
+        R = max(I-bo, first(outerR)):min(I+bo, last(outerR))
+        gc = iX[first(R)..last(R)]/length(R)
+        rst = 0
+        for i in 1:length(offsets)
+            p = CartesianIndex(I.I .+ offsets[i])
+            checkbounds(Bool, X, p.I...) || continue
+            Rp = max(p-bo, first(outerR)):min(p+bo, last(outerR))
+            gp = iX[first(Rp)..last(Rp)]/length(Rp)
+            rst += ifelse(gc <=gp, 1, 0) << (i-1)
+        end
+        out[I] = rst
+    end
+
+    for F in lookups
+        @. out = F[out]
+    end
+
+    return out
+end

--- a/test/multiblock_lbp.jl
+++ b/test/multiblock_lbp.jl
@@ -1,0 +1,116 @@
+@testset "multiblock_lbp" begin
+    # Only the center-value is well-defined in the reference paper [1].
+    # [1] Zhang, Lun, et al. "Face detection based on multi-block lbp representation." _International conference on biometrics_. Springer, Berlin, Heidelberg, 2007.
+    #
+    # 50  0  0      1 0 0    1 0 0
+    #  0  1  0   => 0 x 0 => 0 x 0   => 0b10000001 (129)
+    #  0  0  50     0 0 1    0 0 128
+    X = [
+        50  50  50  0  0  0   0   0   0
+        50  50  50  0  0  0   0   0   0
+        50  50  50  0  0  0   0   0   0
+         0   0   0  1  1  1   0   0   0
+         0   0   0  1  1  1   0   0   0
+         0   0   0  1  1  1   0   0   0
+         0   0   0  0  0  0  50  50  50
+         0   0   0  0  0  0  50  50  50
+         0   0   0  0  0  0  50  50  50
+    ]
+    ref_out = [
+        0    0    0    6  214  214  22  22  22
+        0    0    0    2  214  214  22  22  22
+        0    0    0  130  146  150  22  22  22
+       40    8  136  139  131  147  23  31  31
+      248  248  200  137  129  145  19  31  31
+      248  248  232  201  193  209  17  16  20
+      104  104  104  105   73   65   0   0   0
+      104  104  104  107  107   64   0   0   0
+      104  104  104  107  107   96   0   0   0
+    ]
+
+    out = multiblock_lbp(X, (3, 3))
+    @test eltype(out) == UInt8
+    @test size(out) == (9, 9)
+    @test out == ref_out
+
+    # ensure default parameter values are not changed accidently
+    @test out == multiblock_lbp(X, (3, 3); rotation=false, uniform_degree=nothing)
+
+    # intensity-invariant
+    @test multiblock_lbp(X./255, (3, 3)) == out
+    # Gray inputs
+    @test multiblock_lbp(Gray.(X./255), (3, 3)) == out
+
+    # when `block_size == (1, 1)`, it degenerates to the original pixel version
+    @test multiblock_lbp(X, (1, 1)) == lbp_original(X)
+
+    # LBP is only defined for scalar values
+    @test_throws MethodError multiblock_lbp(RGB.(Gray.(X./255)), (3, 3))
+
+    # not yet ready for N-dimensional array (although it's doable)
+    @test_throws MethodError multiblock_lbp(rand(3, 3, 3), (3, 3))
+
+    @testset "OffsetArrays" begin
+        Xo = OffsetArray(X, -1, -1)
+        out = multiblock_lbp(Xo, (3, 3))
+        @test axes(out) == axes(Xo)
+        @test OffsetArrays.no_offset_view(out) == ref_out
+    end
+
+    @testset "Rotation Invariant" begin
+        ref_out = [
+            0   0   0   3  91  91  11  11  11
+            0   0   0   1  91  91  11  11  11
+            0   0   0   5  37  45  11  11  11
+            5   1  17  23   7  39  23  31  31
+           31  31  25  19   3  25  19  31  31
+           31  31  29  39   7  29  17   1   5
+           13  13  13  45  37   5   0   0   0
+           13  13  13  91  91   1   0   0   0
+           13  13  13  91  91   3   0   0   0
+        ]
+
+        out = multiblock_lbp(X, (3, 3); rotation=true)
+        @test eltype(out) == UInt8
+        @test size(out) == (9, 9)
+        @test out == ref_out
+    end
+
+    @testset "Uniform encoding" begin
+        ref_out = [
+            0    0  0  6  9   9  9   9   9
+            0    0  0  2  9   9  9   9   9
+            0    0  0  9  9   9  9   9   9
+            9    8  9  9  9   9  9  31  31
+          248  248  9  9  9   9  9  31  31
+          248  248  9  9  9   9  9  16   9
+            9    9  9  9  9   9  0   0   0
+            9    9  9  9  9  64  0   0   0
+            9    9  9  9  9  96  0   0   0
+        ]
+
+        out = multiblock_lbp(X, (3, 3); rotation=false, uniform_degree=2)
+        @test eltype(out) == UInt8
+        @test size(out) == (9, 9)
+        @test out == ref_out
+    end
+
+    @testset "Rotation Invariant, Uniform encoding" begin
+        ref_out = [
+            0   0  0  3  9  9  9   9   9
+            0   0  0  1  9  9  9   9   9
+            0   0  0  9  9  9  9   9   9
+            9   1  9  9  7  9  9  31  31
+           31  31  9  9  3  9  9  31  31
+           31  31  9  9  7  9  9   1   9
+            9   9  9  9  9  9  0   0   0
+            9   9  9  9  9  1  0   0   0
+            9   9  9  9  9  3  0   0   0
+        ]
+
+        out = multiblock_lbp(X, (3, 3); rotation=true, uniform_degree=2)
+        @test eltype(out) == UInt8
+        @test size(out) == (9, 9)
+        @test out == ref_out
+    end
+end


### PR DESCRIPTION
A replacement for `ImageFeatures.multi_block_lbp`.

<details>
  <summary> Benchmark report </summary>

# Benchmark Report for *LocalBinaryPatterns*

## Job Properties
* Time of benchmark: 30 Dec 2021 - 11:1
* Package commit: 317f4e
* Julia commit: ac5cc9
* Julia command flags: None
* Environment variables: None

## Results
Below is a table of this job's results, obtained by running the benchmarks.
The values listed in the `ID` column have the structure `[parent_group, child_group, ..., key]`, and can be used to
index into the BaseBenchmarks suite to retrieve the corresponding benchmarks.
The percentages accompanying time and memory values in the below table are noise tolerances. The "true"
time/memory value for a given benchmark is expected to fall within this percentage of the reported value.
An empty cell means that the value was zero.

| ID                                                     | time            | GC time | memory          | allocations |
|--------------------------------------------------------|----------------:|--------:|----------------:|------------:|
| `["Multi-block (1x1)", "Gray{Float32}", "256×256"]`    |   1.228 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (1x1)", "Gray{Float32}", "512×512"]`    |   4.956 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Multi-block (1x1)", "Gray{N0f8}", "256×256"]`       |   1.231 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (1x1)", "Gray{N0f8}", "512×512"]`       |   4.945 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Multi-block (3x3)", "Gray{Float32}", "256×256"]`    |   1.252 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (3x3)", "Gray{Float32}", "512×512"]`    |   4.952 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Multi-block (3x3)", "Gray{N0f8}", "256×256"]`       |   1.248 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (3x3)", "Gray{N0f8}", "512×512"]`       |   4.977 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Multi-block (5x5)", "Gray{Float32}", "256×256"]`    |   1.261 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (5x5)", "Gray{Float32}", "512×512"]`    |   4.979 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Multi-block (5x5)", "Gray{N0f8}", "256×256"]`       |   1.266 ms (5%) |         | 320.25 KiB (1%) |           8 |
| `["Multi-block (5x5)", "Gray{N0f8}", "512×512"]`       |   5.030 ms (5%) |         |   1.25 MiB (1%) |           8 |
| `["Original (mapwindow)", "Gray{Float32}", "256×256"]` |   1.240 ms (5%) |         |   1.34 MiB (1%) |       16340 |
| `["Original (mapwindow)", "Gray{Float32}", "512×512"]` |   4.483 ms (5%) |         |   3.69 MiB (1%) |       32724 |
| `["Original (mapwindow)", "Gray{N0f8}", "256×256"]`    |   1.303 ms (5%) |         |   1.43 MiB (1%) |       19404 |
| `["Original (mapwindow)", "Gray{N0f8}", "512×512"]`    |   4.717 ms (5%) |         |   3.87 MiB (1%) |       38860 |
| `["Original", "Gray{Float32}", "256×256"]`             | 331.563 μs (5%) |         |  64.16 KiB (1%) |           3 |
| `["Original", "Gray{Float32}", "512×512"]`             |   1.330 ms (5%) |         | 256.16 KiB (1%) |           3 |
| `["Original", "Gray{N0f8}", "256×256"]`                | 323.810 μs (5%) |         |  64.16 KiB (1%) |           3 |
| `["Original", "Gray{N0f8}", "512×512"]`                |   1.286 ms (5%) |         | 256.16 KiB (1%) |           3 |

## Benchmark Group List
Here's a list of all the benchmark groups executed by this job:

- `["Multi-block (1x1)", "Gray{Float32}"]`
- `["Multi-block (1x1)", "Gray{N0f8}"]`
- `["Multi-block (3x3)", "Gray{Float32}"]`
- `["Multi-block (3x3)", "Gray{N0f8}"]`
- `["Multi-block (5x5)", "Gray{Float32}"]`
- `["Multi-block (5x5)", "Gray{N0f8}"]`
- `["Original (mapwindow)", "Gray{Float32}"]`
- `["Original (mapwindow)", "Gray{N0f8}"]`
- `["Original", "Gray{Float32}"]`
- `["Original", "Gray{N0f8}"]`

## Julia versioninfo
```
Julia Version 1.7.1
Commit ac5cc99908 (2021-12-22 19:35 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
      Ubuntu 20.04.3 LTS
  uname: Linux 5.10.16.3-microsoft-standard-WSL2 #1 SMP Fri Apr 2 22:23:49 UTC 2021 x86_64 x86_64
  CPU: 12th Gen Intel(R) Core(TM) i9-12900K: 
                 speed         user         nice          sys         idle          irq
       #1-24  3187 MHz      18467 s        421 s       5006 s    3616098 s          0 s
       
  Memory: 31.25204849243164 GB (25271.359375 MB free)
  Uptime: 15179.22 sec
  Load Avg:  1.14  1.03  0.66
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, goldmont)
```
</details>